### PR TITLE
PATCH/IIGA2-1216 - Enable new google apis

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,10 @@ resource "google_project_service" "enable_api" {
   for_each = toset([
     "accesscontextmanager.googleapis.com",
     "cloudkms.googleapis.com",
-    "dataproc.googleapis.com"
+    "dataproc.googleapis.com",
+    "pubsub.googleapis.com",
+    "eventarc.googleapis.com",
+    "cloudfunctions.googleapis.com"
   ])
   project = var.data_plane_project
   service = each.value


### PR DESCRIPTION
Enable the following GCP APIs:
- pubsub.googleapis.com
- eventarc.googleapis.com
- cloudfunctions.googleapis.com