### PR TITLE
MINOR/IIGA2-1360 Add api.liveramp.com egress rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea/
+.terraform/

--- a/firewalls.tf
+++ b/firewalls.tf
@@ -40,6 +40,26 @@ resource "google_compute_firewall" "allow_idapi_egress" {
   destination_ranges = var.idapi_cidr_ip_addresses
 }
 
+resource "google_compute_firewall" "allow_query_engine_egress" {
+  count       = var.enable_dataproc_network ? 1 : 0
+  project     = google_compute_network.vpc_network[*].project
+  name        = "allow-${var.installation_name}-qe-egress"
+  network     = google_compute_network.vpc_network[*].name
+  direction   = "EGRESS"
+  priority    = "1000"
+  description = "Allow EGRESS to LiveRamp api.liveramp.com"
+
+  allow {
+    protocol = "tcp"
+
+    ports = [
+      "443"
+    ]
+  }
+
+  destination_ranges = var.query_engine_ip_address
+}
+
 module "dataproc-firewall-rules" {
   count        = var.enable_dataproc_network ? 1 : 0
   source       = "terraform-google-modules/network/google//modules/firewall-rules"

--- a/variables.tf
+++ b/variables.tf
@@ -94,6 +94,12 @@ variable "idapi_cidr_ip_addresses" {
   description = "Portrait Engine ID-API instance CIDR IP addresses"
 }
 
+variable "query_engine_ip_address" {
+  type        = string
+  default     = "34.149.99.209"
+  description = "Portrait Engine ID-API instance CIDR IP addresses"
+}
+
 variable "enable_dataproc_network" {
   type        = bool
   description = "Configure network bits for Dataproc - VPC, firewall rules etc"


### PR DESCRIPTION
Jira: https://liveramp.atlassian.net/browse/IIGA2-1360

# Context 
To allow connection between query engine and the dataproc cluster running in the data plane;  api.liveramp.com needs to be whitelisted in the egress rules 

As per https://liveramp.atlassian.net/browse/OC-50929 we need to add `34.149.99.209` to the egress rules - [authoritative ref](https://github.com/LiveRamp/tf_dns/blob/0035ae9994b1a9162b7b11d71b631da8ea505aa8/liveramp_com/liveramp.com.tf#L5-L17)
