### PR TITLE
MINOR/IIGA2-1405 - Create HMAC keys for LiveRamp tenants

### DIFF
--- a/service-accounts.tf
+++ b/service-accounts.tf
@@ -7,3 +7,14 @@ resource "google_service_account" "tenant_data_access" {
   account_id  = lower("${var.name}-${random_id.generator.hex}")
   description = "Tenant data access serviceAccount for = ${var.installation_name} - ${title(var.name)} ${upper(var.country_code)}"
 }
+
+resource "google_service_account" "tenant_data_access" {
+  project     = var.data_plane_project
+  account_id  = lower("${var.name}-${random_id.generator.hex}")
+  description = "Tenant data access serviceAccount for = ${var.installation_name} - ${title(var.name)} ${upper(var.country_code)}"
+}
+
+resource "google_storage_hmac_key" "tenant_query_engine_access" {
+  count                 = var.enable_liveramp_query_engine ? 1 : 0
+  service_account_email = tenant_data_access.service_account.email
+}

--- a/variables.tf
+++ b/variables.tf
@@ -106,3 +106,9 @@ variable "enable_kms" {
   default     = true
 }
 
+variable "enable_liveramp_query_engine" {
+  type        = bool
+  description = "Create HMAC keys for LiveRamp's Query Engine to be used in data plane"
+  default     = false
+}
+


### PR DESCRIPTION
The PR adds a new variable to create HMAC keys for SingleStore clusters to write the data into our bucket.