### PR TITLE
MINOR/IIGA2-1405 - Create HMAC keys for LiveRamp tenants

### DIFF
--- a/service-accounts.tf
+++ b/service-accounts.tf
@@ -7,3 +7,8 @@ resource "google_service_account" "tenant_data_access" {
   account_id  = lower("${var.name}-${random_id.generator.hex}")
   description = "Tenant data access serviceAccount for = ${var.installation_name} - ${title(var.name)} ${upper(var.country_code)}"
 }
+
+resource "google_storage_hmac_key" "tenant_query_engine_access" {
+  count                 = var.enable_liveramp_query_engine ? 1 : 0
+  service_account_email = tenant_data_access.service_account.email
+}

--- a/variables.tf
+++ b/variables.tf
@@ -106,3 +106,8 @@ variable "enable_kms" {
   default     = true
 }
 
+variable "enable_liveramp_query_engine" {
+  type        = bool
+  description = "Create HMAC keys for LiveRamp's Query Engine to be used in data plane, should be enabled only to access LiveRamp data"
+  default     = false
+}


### PR DESCRIPTION
Successor of https://github.com/LiveRamp/terraform-google-identity-engine-data-plane/pull/39