### PR TITLE
PATCH/NO-JIRA - rm hmac keys

### DIFF
--- a/service-accounts.tf
+++ b/service-accounts.tf
@@ -7,8 +7,3 @@ resource "google_service_account" "tenant_data_access" {
   account_id  = lower("${var.name}-${random_id.generator.hex}")
   description = "Tenant data access serviceAccount for = ${var.installation_name} - ${title(var.name)} ${upper(var.country_code)}"
 }
-
-resource "google_storage_hmac_key" "tenant_query_engine_access" {
-  count                 = var.enable_liveramp_query_engine ? 1 : 0
-  service_account_email = google_service_account.tenant_data_access.email
-}

--- a/variables.tf
+++ b/variables.tf
@@ -105,9 +105,3 @@ variable "enable_kms" {
   description = "Configure KMS to encrypt build, input and output buckets"
   default     = true
 }
-
-variable "enable_liveramp_query_engine" {
-  type        = bool
-  description = "Create HMAC keys for LiveRamp's Query Engine to be used in data plane, should be enabled only to access LiveRamp data"
-  default     = false
-}


### PR DESCRIPTION
At this point, we'd not keep HMAC key creation as part of data-plane module.

Reasons:
- Main reason being, that only ODM tenant would use this as of now
- Second reason is, to share HMAC keys with other relevant teams we need Vault resources to be created through infra monorepo, and in order to do that, we need to be able to register hmac resource (to output hmac secret values from data-plane module isn't feasible)