### PR TITLE
PATCH/IIGA2-1747 Add additional outputs to dataplane

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea/
+.terraform/

--- a/outputs.tf
+++ b/outputs.tf
@@ -35,12 +35,12 @@ output "output_bucket_name" {
   description = "The name of the GCS bucket that will be used to store the output files"
 }
 
-output "cloud_nat_static_ip_address" {
-  value       = default(google_compute_address.cloud_nat_static_ip_address.address, null)
-  description = "The static IP address for Cloud NAT"
+output "cloud_nat_static_ip_address_1" {
+  value       = element(google_compute_address.cloud_nat_static_ip_address.*.address, 0)
+  description = "The first static IP address for Cloud NAT"
 }
 
-output "dataproc_subnet" {
-  value       = default(google_compute_subnetwork.dataproc_subnet, null)
-  description = "The subnetwork object that will be used by the Dataproc cluster"
+output "cloud_nat_static_ip_address_2" {
+  value       = element(google_compute_address.cloud_nat_static_ip_address.*.address, 1)
+  description = "The second static IP address for Cloud NAT"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,13 +1,21 @@
 output "tenant_organisation_id" {
   value = var.organisation_id
+  description = "The tenant organisation ID"
 }
 
 output "tenant_name" {
   value = var.name
+  description = "The tenant name"
 }
 
 output "tenant_project" {
   value = data.google_project.data_plane_project
+  description = "The tenant project object"
+}
+
+output "tenant_project_id" {
+  value = data.google_project.data_plane_project.project_id
+  description = "The tenant project ID"
 }
 
 output "tenant_data_access_svc_account" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -41,6 +41,6 @@ output "cloud_nat_static_ip_address" {
 }
 
 output "dataproc_subnet" {
-  value       = coalesce(google_compute_subnetwork.dataproc_subnet[0].id, null)
+  value       = try(google_compute_subnetwork.dataproc_subnet[0].id, null)
   description = "The ID of the Dataproc subnet"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -39,7 +39,7 @@ output "output_bucket_name" {
 }
 
 output "cloud_nat_static_ip_address" {
-  value       = coalesce(google_compute_address.cloud_nat_static_ip_address.*.address, null)
+  value       = coalescelist(google_compute_address.cloud_nat_static_ip_address.address, null)
   description = "The static IP addresses for Cloud NAT"
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,11 +13,6 @@ output "tenant_project" {
   description = "The tenant project object"
 }
 
-output "tenant_project_id" {
-  value = data.google_project.data_plane_project.project_id
-  description = "The tenant project ID"
-}
-
 output "tenant_data_access_svc_account" {
   value       = google_service_account.tenant_data_access
   description = "The service account object that will be used to access the tenant data"

--- a/outputs.tf
+++ b/outputs.tf
@@ -39,12 +39,12 @@ output "output_bucket_name" {
 }
 
 output "cloud_nat_static_ip_address_0" {
-  value       = coalesce(google_compute_address.cloud_nat_static_ip_address[0].address, null)
+  value       = try(google_compute_address.cloud_nat_static_ip_address[0].address, null)
   description = "The static IP addresses for Cloud NAT"
 }
 
 output "cloud_nat_static_ip_address_1" {
-  value       = coalesce(google_compute_address.cloud_nat_static_ip_address[1].address, null)
+  value       = try(google_compute_address.cloud_nat_static_ip_address[1].address, null)
   description = "The static IP addresses for Cloud NAT"
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -38,14 +38,14 @@ output "output_bucket_name" {
   description = "The name of the GCS bucket that will be used to store the output files"
 }
 
-output "cloud_nat_static_ip_address_0" {
+output "ABDCDEF" {
   value       = try(google_compute_address.cloud_nat_static_ip_address[0].address, "")
-  description = "The static IP addresses for Cloud NAT"
+  description = "The first static IP address for Cloud NAT"
 }
 
-output "cloud_nat_static_ip_address_1" {
+output "KUSH_2" {
   value       = try(google_compute_address.cloud_nat_static_ip_address[1].address, "")
-  description = "The static IP addresses for Cloud NAT"
+  description = "The second static IP address for Cloud NAT"
 }
 
 output "dataproc_subnet" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -39,12 +39,12 @@ output "output_bucket_name" {
 }
 
 output "cloud_nat_static_ip_address_0" {
-  value       = try(google_compute_address.cloud_nat_static_ip_address[0].address, null)
+  value       = try(google_compute_address.cloud_nat_static_ip_address[0].address, "")
   description = "The static IP addresses for Cloud NAT"
 }
 
 output "cloud_nat_static_ip_address_1" {
-  value       = try(google_compute_address.cloud_nat_static_ip_address[1].address, null)
+  value       = try(google_compute_address.cloud_nat_static_ip_address[1].address, "")
   description = "The static IP addresses for Cloud NAT"
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -49,6 +49,6 @@ output "cloud_nat_static_ip_address_1" {
 }
 
 output "dataproc_subnet" {
-  value       = try(google_compute_subnetwork.dataproc_subnet.*.name, "")
+  value       = try(google_compute_subnetwork.dataproc_subnet[0].name, "")
   description = "The ID of the Dataproc subnet"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -38,17 +38,17 @@ output "output_bucket_name" {
   description = "The name of the GCS bucket that will be used to store the output files"
 }
 
-output "ABDCDEF" {
+output "cloud_nat_static_ip_address_0" {
   value       = try(google_compute_address.cloud_nat_static_ip_address[0].address, "")
   description = "The first static IP address for Cloud NAT"
 }
 
-output "KUSH_2" {
+output "cloud_nat_static_ip_address_1" {
   value       = try(google_compute_address.cloud_nat_static_ip_address[1].address, "")
   description = "The second static IP address for Cloud NAT"
 }
 
 output "dataproc_subnet" {
-  value       = try(google_compute_subnetwork.dataproc_subnet, null)
+  value       = try(google_compute_subnetwork.dataproc_subnet.*.name, "")
   description = "The ID of the Dataproc subnet"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -36,6 +36,6 @@ output "output_bucket_name" {
 }
 
 output "cloud_nat_static_ip_address" {
-  value       = coalesce(google_compute_address.cloud_nat_static_ip_address.address, null)
-  description = "The static IP address for Cloud NAT"
+  value       = coalesce(google_compute_address.cloud_nat_static_ip_address.*.address, [])
+  description = "The static IP addresses for Cloud NAT"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -44,6 +44,6 @@ output "cloud_nat_static_ip_address" {
 }
 
 output "dataproc_subnet" {
-  value       = coalesce(google_compute_subnetwork.dataproc_subnet.*.id, null)
+  value       = try(google_compute_subnetwork.dataproc_subnet, null)
   description = "The ID of the Dataproc subnet"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -38,8 +38,13 @@ output "output_bucket_name" {
   description = "The name of the GCS bucket that will be used to store the output files"
 }
 
-output "cloud_nat_static_ip_address" {
-  value       = coalescelist(google_compute_address.cloud_nat_static_ip_address.address, null)
+output "cloud_nat_static_ip_address_0" {
+  value       = coalesce(google_compute_address.cloud_nat_static_ip_address[0].address, null)
+  description = "The static IP addresses for Cloud NAT"
+}
+
+output "cloud_nat_static_ip_address_1" {
+  value       = coalesce(google_compute_address.cloud_nat_static_ip_address[1].address, null)
   description = "The static IP addresses for Cloud NAT"
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -41,6 +41,6 @@ output "cloud_nat_static_ip_address" {
 }
 
 output "dataproc_subnet" {
-  value       = try(google_compute_subnetwork.dataproc_subnet[0].id, null)
+  value       = coalesce(google_compute_subnetwork.dataproc_subnet.*.id, null)
   description = "The ID of the Dataproc subnet"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -36,7 +36,7 @@ output "output_bucket_name" {
 }
 
 output "cloud_nat_static_ip_address" {
-  value       = coalesce(google_compute_address.cloud_nat_static_ip_address.*.address, [])
+  value       = coalesce(google_compute_address.cloud_nat_static_ip_address.*.address, null)
   description = "The static IP addresses for Cloud NAT"
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -39,3 +39,8 @@ output "cloud_nat_static_ip_address" {
   value       = coalesce(google_compute_address.cloud_nat_static_ip_address.*.address, [])
   description = "The static IP addresses for Cloud NAT"
 }
+
+output "dataproc_subnet" {
+  value       = coalesce(google_compute_subnetwork.dataproc_subnet[0].id, null)
+  description = "The ID of the Dataproc subnet"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -35,12 +35,7 @@ output "output_bucket_name" {
   description = "The name of the GCS bucket that will be used to store the output files"
 }
 
-output "cloud_nat_static_ip_address_1" {
-  value       = element(google_compute_address.cloud_nat_static_ip_address.*.address, 0)
-  description = "The first static IP address for Cloud NAT"
-}
-
-output "cloud_nat_static_ip_address_2" {
-  value       = element(google_compute_address.cloud_nat_static_ip_address.*.address, 1)
-  description = "The second static IP address for Cloud NAT"
+output "cloud_nat_static_ip_address" {
+  value       = coalesce(google_compute_address.cloud_nat_static_ip_address.address, null)
+  description = "The static IP address for Cloud NAT"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -35,3 +35,12 @@ output "output_bucket_name" {
   description = "The name of the GCS bucket that will be used to store the output files"
 }
 
+output "cloud_nat_static_ip_address" {
+  value       = default(google_compute_address.cloud_nat_static_ip_address.address, null)
+  description = "The static IP address for Cloud NAT"
+}
+
+output "dataproc_subnet" {
+  value       = default(google_compute_subnetwork.dataproc_subnet, null)
+  description = "The subnetwork object that will be used by the Dataproc cluster"
+}


### PR DESCRIPTION
Add the following outputs to the module: 
`cloud_nat_static_ip_address` 
`dataproc_subnet` 

The outputs will return  an empty string as a default