### PR TITLE
MINOR/IIGA2-1799 Make Tenant Input and Output buckets Read Only

### DIFF
--- a/buckets.tf
+++ b/buckets.tf
@@ -122,21 +122,6 @@ resource "google_storage_bucket" "tenant_output_bucket" {
 
 data "google_iam_policy" "tenant_output_bucket" {
   binding {
-    role = "roles/storage.admin"
-    members = [
-      "projectOwner:${var.data_plane_project}"
-    ]
-  }
-  binding {
-    role = "roles/storage.objectUser"
-    members = concat(
-      local.prefixed_editor_list,
-      [
-        "serviceAccount:${google_service_account.tenant_data_access.email}",
-      ]
-    )
-  }
-  binding {
     role = "roles/storage.objectViewer"
     members = concat(
       local.prefixed_reader_list,
@@ -197,21 +182,6 @@ resource "google_storage_bucket" "tenant_input_bucket" {
 }
 
 data "google_iam_policy" "tenant_input_bucket" {
-  binding {
-    role = "roles/storage.admin"
-    members = [
-      "projectOwner:${var.data_plane_project}"
-    ]
-  }
-  binding {
-    role = "roles/storage.objectUser"
-    members = concat(
-      local.prefixed_editor_list,
-      [
-        "serviceAccount:${google_service_account.tenant_data_access.email}",
-      ]
-    )
-  }
   binding {
     role = "roles/storage.objectViewer"
     members = concat(


### PR DESCRIPTION
>Make Input and Output buckets read only for everyone for all tenants, to allow deleting them in the future.

Jira: https://liveramp.atlassian.net/browse/IIGA2-1799

Testing: Performed in DEV environments through terraform plan